### PR TITLE
fix: sidebar scroll and semantic/SQL mode toggle

### DIFF
--- a/src/lib/plugin/TableBrowser.svelte
+++ b/src/lib/plugin/TableBrowser.svelte
@@ -404,15 +404,31 @@
 	</div>
 
 	<div class="rounded-lg border border-gray-300 bg-white/60 p-4 shadow backdrop-blur-lg">
-		<div class="tabs-boxed tabs mb-2 w-max">
+		<div
+			class="mb-3 inline-flex rounded-full border border-gray-300/80 bg-gray-100/90 p-0.5 shadow-inner"
+			role="group"
+			aria-label="Query mode"
+		>
 			<button
-				class="tab"
-				class:tab-active={query_mode === "semantic"}
+				type="button"
+				class="rounded-full px-4 py-1.5 text-sm font-medium transition-colors focus:ring-2 focus:ring-blue-500/40 focus:outline-none"
+				class:bg-white={query_mode === "semantic"}
+				class:text-blue-700={query_mode === "semantic"}
+				class:shadow-sm={query_mode === "semantic"}
+				class:text-gray-600={query_mode !== "semantic"}
+				class:hover:text-gray-900={query_mode !== "semantic"}
+				aria-pressed={query_mode === "semantic"}
 				on:click={() => (query_mode = "semantic")}>Semantic</button
 			>
 			<button
-				class="tab"
-				class:tab-active={query_mode === "sql"}
+				type="button"
+				class="rounded-full px-4 py-1.5 text-sm font-medium transition-colors focus:ring-2 focus:ring-blue-500/40 focus:outline-none"
+				class:bg-white={query_mode === "sql"}
+				class:text-blue-700={query_mode === "sql"}
+				class:shadow-sm={query_mode === "sql"}
+				class:text-gray-600={query_mode !== "sql"}
+				class:hover:text-gray-900={query_mode !== "sql"}
+				aria-pressed={query_mode === "sql"}
 				on:click={() => (query_mode = "sql")}>SQL</button
 			>
 		</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,8 +38,10 @@
 </svelte:head>
 
 <div class="grid h-dvh w-full grid-cols-[280px_1fr] bg-gray-100 font-sans text-gray-800">
-	<!-- Sidebar -->
-	<div class="flex flex-col border-r border-white/20 bg-gray-800/80 text-white backdrop-blur-lg">
+	<!-- Sidebar: min-h-0 so flex/grid children can shrink and overflow-y-auto scrolls -->
+	<div
+		class="flex min-h-0 flex-col border-r border-white/20 bg-gray-800/80 text-white backdrop-blur-lg"
+	>
 		<div class="flex h-20 flex-shrink-0 items-center gap-4 px-6">
 			<img
 				src="https://cdn.playcdu.co/Images/Branding/Blue/BH_NU_Asset_6.png"
@@ -48,7 +50,7 @@
 			/>
 			<span class="text-xl font-semibold">D1 Manager</span>
 		</div>
-		<div class="flex-1 overflow-y-auto p-4">
+		<div class="min-h-0 flex-1 overflow-y-auto p-4">
 			<nav class="flex flex-col gap-4">
 				<div>
 					<h2 class="mb-2 text-sm font-bold tracking-wider text-gray-400 uppercase">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two small UI fixes for the D1 manager layout and table browser.

## Changes

### Sidebar scrolling

The sidebar nav already used `overflow-y-auto`, but as a grid child it could not shrink below the height of its content. Grid items default to `min-height: auto`, which blocks overflow scrolling when the table list is taller than the viewport.

- Add `min-h-0` to the sidebar column and to the scrollable `flex-1` region in `+layout.svelte` so databases and tables can scroll.

### Semantic / SQL mode control

The previous control used DaisyUI `tabs` / `tab` classes, but this project uses Tailwind only (no DaisyUI), so the switch looked like unstyled plain text.

- Replace it with a pill **segmented toggle**: track background, white pill for the active option, stronger typography, focus rings, `type="button"`, and `aria-pressed` for accessibility.

## Testing

- `pnpm check` still reports existing issues in `TableBrowser.svelte` (types, a11y) and db pages unrelated to these markup/class changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57269268-905e-453a-a930-49bf0f8d37fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57269268-905e-453a-a930-49bf0f8d37fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

